### PR TITLE
Sort and color code tasks based on status

### DIFF
--- a/src/app/_components/board.tsx
+++ b/src/app/_components/board.tsx
@@ -1,14 +1,14 @@
 "use client";
 
 import { Pacifico } from "next/font/google";
-import { api, type RouterOutputs } from "~/trpc/react";
-import Link from "next/link";
+import { type RouterOutputs } from "~/trpc/react";
 import { Button } from "~/app/_components/ui/button";
 import { RotateCwIcon } from "lucide-react";
 import { useState } from "react";
 import { type User } from "next-auth";
 import { TaskTile } from "~/app/_components/task-tile";
 import ReactCardFlip from "react-card-flip";
+import { useUpdatedTasks } from "~/app/useUpdatedTasks";
 
 export const pacifico = Pacifico({
   weight: "400",
@@ -27,38 +27,8 @@ interface BoardProps {
   currentGroup: User;
 }
 
-export const Board = ({ tasks: initialTasks, currentGroup }: BoardProps) => {
-  const [tasks, setTasks] = useState(initialTasks);
+export const Board = ({ tasks, currentGroup }: BoardProps) => {
   const [isFlipped, setIsFlipped] = useState(false);
-
-  api.groupTask.onGroupTaskChanged.useSubscription(undefined, {
-    onData: (groupTask) => {
-      setTasks((tasks) => {
-        return tasks.map((task) => {
-          if (task.id !== groupTask.data.taskId) {
-            return task;
-          }
-          const groupTaskContained = task.groups.some(
-            (gt) => gt.groupId === groupTask.data.groupId,
-          );
-          return {
-            ...task,
-            groups: groupTaskContained
-              ? task.groups.map((group) => {
-                  if (group.groupId !== groupTask.data.groupId) {
-                    return group;
-                  }
-                  return {
-                    ...group,
-                    status: groupTask.data.status,
-                  };
-                })
-              : [...task.groups, groupTask.data],
-          };
-        });
-      });
-    },
-  });
 
   const taskColumns = tasks
     .reduce((cols, task) => {

--- a/src/app/_components/game.tsx
+++ b/src/app/_components/game.tsx
@@ -13,6 +13,7 @@ import {
   TabsList,
   TabsTrigger,
 } from "~/app/_components/ui/tabs";
+import { useUpdatedTasks } from "~/app/useUpdatedTasks";
 
 type GetAllTask = RouterOutputs["task"]["getAll"][number];
 
@@ -22,7 +23,13 @@ interface GameProps {
   groups: Group[];
 }
 
-export const Game = ({ tasks, currentGroup, groups }: GameProps) => {
+export const Game = ({
+  tasks: initialTasks,
+  currentGroup,
+  groups,
+}: GameProps) => {
+  const tasks = useUpdatedTasks(initialTasks);
+
   return (
     <div className="mt-4 flex w-full flex-col items-center">
       <div className="flex w-full max-w-screen-md flex-col items-center px-3">

--- a/src/app/_components/scoreboard.tsx
+++ b/src/app/_components/scoreboard.tsx
@@ -1,10 +1,8 @@
 "use client";
 
-import { type RouterOutputs } from "~/trpc/react";
 import { Group } from "@prisma/client";
 import { pacifico } from "./board";
-
-type GetAllTask = RouterOutputs["task"]["getAll"][number];
+import { GetAllTask } from "~/app/useUpdatedTasks";
 
 export const Scoreboard = ({
   tasks,

--- a/src/app/useUpdatedTasks.ts
+++ b/src/app/useUpdatedTasks.ts
@@ -1,0 +1,39 @@
+import { api, RouterOutputs } from "~/trpc/react";
+import { useState } from "react";
+
+export type GetAllTask = RouterOutputs["task"]["getAll"][number];
+
+export const useUpdatedTasks = (initialTasks: GetAllTask[]) => {
+  const [tasks, setTasks] = useState(initialTasks);
+
+  api.groupTask.onGroupTaskChanged.useSubscription(undefined, {
+    onData: (groupTask) => {
+      setTasks((tasks) => {
+        return tasks.map((task) => {
+          if (task.id !== groupTask.data.taskId) {
+            return task;
+          }
+          const groupTaskContained = task.groups.some(
+            (gt) => gt.groupId === groupTask.data.groupId,
+          );
+          return {
+            ...task,
+            groups: groupTaskContained
+              ? task.groups.map((group) => {
+                  if (group.groupId !== groupTask.data.groupId) {
+                    return group;
+                  }
+                  return {
+                    ...group,
+                    status: groupTask.data.status,
+                  };
+                })
+              : [...task.groups, groupTask.data],
+          };
+        });
+      });
+    },
+  });
+
+  return tasks;
+};


### PR DESCRIPTION
Makes the job for admins a bit easier as any tasks the selected group has "sent" and "started" will appear at the top of the list for approval.

<img width="1296" alt="Screenshot 2024-08-22 at 15 22 26" src="https://github.com/user-attachments/assets/9e9e1e61-bf48-4083-a9a5-66fcd156989d">
